### PR TITLE
Release container image through GitHub as part of release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,3 +19,12 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
+
+  container-main:
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: audito-maldito
+      tag: ${{ github.ref_name }}
+      registry_org: ${{ github.repository }}
+      dockerfile_path: Dockerfile
+      platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This is the last bit for the GitHub Actions migration.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
