### PR TITLE
Fall back to using `gethostname` if no `NODE_NAME` environment variable is given

### DIFF
--- a/internal/common/nodename.go
+++ b/internal/common/nodename.go
@@ -1,11 +1,9 @@
 package common
 
 import (
-	"errors"
+	"fmt"
 	"os"
 )
-
-var ErrNoNodeNameGiven = errors.New("no node name given")
 
 // GetNodeName returns the node name.
 // It reads it from the NODE_NAME environment variable.
@@ -13,7 +11,11 @@ func GetNodeName() (string, error) {
 	nodename := os.Getenv("NODE_NAME")
 
 	if nodename == "" {
-		return "", ErrNoNodeNameGiven
+		var err error
+		nodename, err = os.Hostname()
+		if err != nil {
+			return "", fmt.Errorf("error getting hostname: %w", err)
+		}
 	}
 
 	return nodename, nil

--- a/internal/common/nodename_test.go
+++ b/internal/common/nodename_test.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:paralleltest // We can't ensure env variable consistency in parallel tests.
+func TestGetNodeNameWithEnvVar(t *testing.T) {
+	t.Setenv("NODE_NAME", "test")
+
+	nodename, err := GetNodeName()
+	assert.NoError(t, err, "error getting node name")
+
+	assert.Equal(t, "test", nodename, "node name is not equal")
+}
+
+//nolint:paralleltest // We can't ensure env variable consistency in parallel tests.
+func TestGetNodeNameWithoutEnvVar(t *testing.T) {
+	hostname, err := os.Hostname()
+	assert.NoError(t, err, "error getting hostname")
+
+	nodename, err := GetNodeName()
+	assert.NoError(t, err, "error getting node name")
+
+	assert.Equal(t, hostname, nodename, "node name is not equal")
+}


### PR DESCRIPTION
This enables users running audito-maldito outside of k8s to require less
setup.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
