### PR TITLE
auditd: Temporary "fix" for deadlock.

### DIFF
--- a/internal/auditd/auditd.go
+++ b/internal/auditd/auditd.go
@@ -64,7 +64,12 @@ func (o *Auditd) Read(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create new auditd message resassembler - %w", err)
 	}
-	defer reassembler.Close()
+	// TODO: Calling reassembler.Close is not safe because
+	// it then calls our reassemblerCB, which then tries to
+	// write to the reassembleAuditdEvents channel - which
+	// no Go routine will be listening to it. This is super
+	// unclear from the Close documentation.
+	// defer reassembler.Close()
 
 	go maintainReassemblerLoop(ctx, reassembler, reassemblerInterval)
 


### PR DESCRIPTION
During deployment, we found that audito-maldito would deadlock when writing a UserLogin event to the RemoteUser logins channel (see "internal/journald/processentry.go", line 240).

We found that the go-libaudit Reassembler.Close method was executing our reassembler call-back's methods - which results in a write to the reassembleAuditdEvents channel. When coupled with a "defer" statement, the Close method deadlocked because:

  - The context.Context was not marked as done
  - No Go routines are reading from reassembleAuditdEvents

The Reassembler.Close method should *really* reflect that it calls the reassembler callback.