### PR TITLE
Make sessiontracker use thread-safe constructs

### DIFF
--- a/internal/auditd/sessiontracker_test.go
+++ b/internal/auditd/sessiontracker_test.go
@@ -188,12 +188,11 @@ func TestSessionTracker_RemoteLogin_DoesNotHaveAuditSessionCache(t *testing.T) {
 	assert.Equal(t, expRUL, observedLogin)
 }
 
-//nolint // Maybe the linter should read the documentation
 func TestSessionTracker_AuditdEvent_NoSessionID(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancelFn := context.WithTimeout(context.Background(), time.Second)
-	defer cancelFn()
+	t.Cleanup(cancelFn)
 
 	st := newSessionTracker(auditevent.NewAuditEventWriter(&testAuditEncoder{
 		ctx:    ctx,
@@ -201,22 +200,20 @@ func TestSessionTracker_AuditdEvent_NoSessionID(t *testing.T) {
 		t:      t,
 	}))
 
-	//nolint // Maybe the linter should read the documentation
 	t.Run("EmptyString", func(t *testing.T) {
+		t.Parallel()
+
 		err := st.auditdEvent(newAucoalesceEvent(t, "", "success", time.Now()))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err, "expected no error when session ID is empty string")
 
 		assert.Equal(t, st.sessIDsToUsers.Len(), 0)
 	})
 
-	//nolint // Maybe the linter should read the documentation
 	t.Run("Unset", func(t *testing.T) {
+		t.Parallel()
+
 		err := st.auditdEvent(newAucoalesceEvent(t, "unset", "success", time.Now()))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err, "expected no error when session ID is unset")
 
 		assert.Equal(t, st.sessIDsToUsers.Len(), 0)
 	})

--- a/internal/common/genericsyncmap.go
+++ b/internal/common/genericsyncmap.go
@@ -1,0 +1,72 @@
+package common
+
+import "sync"
+
+// GenericSyncMap is a generic sync.Map.
+type GenericSyncMap[K comparable, V any] struct {
+	// Map is the underlying map.
+	m   map[K]V
+	mtx sync.Mutex
+}
+
+// NewGenericSyncMap returns a new GenericSyncMap.
+func NewGenericSyncMap[K comparable, V any]() *GenericSyncMap[K, V] {
+	return &GenericSyncMap[K, V]{
+		m: make(map[K]V),
+	}
+}
+
+// Load returns the value stored in the map for a key, or nil if no
+// value is present. The ok result indicates whether value was found
+// in the map.
+func (m *GenericSyncMap[K, V]) Load(key K) (V, bool) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	value, ok := m.m[key]
+	return value, ok
+}
+
+// Store sets the value for a key.
+func (m *GenericSyncMap[K, V]) Store(key K, value V) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	m.m[key] = value
+}
+
+// Delete deletes the value for a key.
+func (m *GenericSyncMap[K, V]) Delete(key K) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	m.DeleteUnsafe(key)
+}
+
+// DeleteUnsafe deletes the value for a key without locking.
+func (m *GenericSyncMap[K, V]) DeleteUnsafe(key K) {
+	delete(m.m, key)
+}
+
+// Len returns the number of items in the map.
+func (m *GenericSyncMap[K, V]) Len() int {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	return len(m.m)
+}
+
+// Iterate iterates over the map and calls the callback for each key/value
+// pair. If the callback returns false, the iteration stops.
+// Note that the callback is called while the map is locked, so it should
+// not call any methods on the map.
+func (m *GenericSyncMap[K, V]) Iterate(cb func(key K, value V) bool) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	for k, v := range m.m {
+		if !cb(k, v) {
+			break
+		}
+	}
+}


### PR DESCRIPTION
This makes the session tracker use thread-safe constructs for storing and accessing the session ID to users and the PID to Remote User Login maps.

To do this, I created a generic map structure that locks it's contents with a mutex for safe concurrent access.

In order to test this further, Added more thorough testing and documentation to `TestSessionTracker_AuditdEvent_ExistingSession_Ended` which seemed like a relevant function to verify.

Since the session tracker can now be parallelized, the `TestSessionTracker_AuditdEvent_NoSessionID` test was marked and modified as such.
