### PR TITLE
Fix: Not logging when no certificate but success login

### DIFF
--- a/internal/journald/processentry.go
+++ b/internal/journald/processentry.go
@@ -183,7 +183,16 @@ func processAcceptPublicKeyEntry(config *processEntryConfig) error {
 			// merits us panicking here.
 			return fmt.Errorf("failed to write event: %w", err)
 		}
-		return nil
+		select {
+		case <-config.ctx.Done():
+			return nil
+		case config.logins <- common.RemoteUserLogin{
+			Source:     evt,
+			PID:        pid,
+			CredUserID: common.UnknownUser,
+		}:
+			return nil
+		}
 	}
 
 	certIdentifierStringStart := len(matches[0]) + 1


### PR DESCRIPTION
We were currently dropping events when a non certificate remote login attempt happened and the user was unknown.

e.g. This only logged this message but no event:
```json
{
  "level": "info",
  "ts": 1680689060.9600282,
  "caller": "journald/processentry.go:179",
  "msg": "a: got login entry with no matches for certificate identifiers"
}
```
For this type of entry:
```
Apr 05 12:44:05 ynot-dev-box-12314 sshd[149010]: Accepted publickey for root from 89.18.65.131 port 60268 ssh2: ED25519 SHA256:qZqq9LIYI5PqrbackEJWI6qjydwiQzkC1z0NrwSCC10
Apr 05 12:44:05 ynot-dev-box-12314 sshd[149010]: pam_unix(sshd:session): session opened for user root by (uid=0)
```

Note: This does not add details for password logins.