### PR TITLE
Remove one level of channels using session tracker directly

### DIFF
--- a/internal/auditd/reassembler_callback.go
+++ b/internal/auditd/reassembler_callback.go
@@ -1,0 +1,50 @@
+package auditd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/go-libaudit/v2"
+	"github.com/elastic/go-libaudit/v2/aucoalesce"
+	"github.com/elastic/go-libaudit/v2/auparse"
+
+	"github.com/metal-toolbox/audito-maldito/internal/auditd/sessiontracker"
+)
+
+var _ libaudit.Stream = &reassemblerCB{}
+
+// reassemblerCB implements the libaudit.Stream interface.
+type reassemblerCB struct {
+	au     sessiontracker.Auditor
+	errors chan<- error
+	after  time.Time
+}
+
+func (s *reassemblerCB) ReassemblyComplete(msgs []*auparse.AuditMessage) {
+	event, err := aucoalesce.CoalesceMessages(msgs)
+	if err != nil {
+		s.errors <- &reassemblerCBError{
+			message: fmt.Sprintf("failed to coalesce audit messages - %s", err),
+			inner:   err,
+		}
+
+		return
+	}
+
+	if event.Timestamp.Before(s.after) {
+		return
+	}
+
+	aucoalesce.ResolveIDs(event)
+
+	if err := s.au.AuditdEvent(event); err != nil {
+		s.errors <- &reassemblerCBError{
+			message: fmt.Sprintf("failed to audit audit event - %s", err),
+			inner:   err,
+		}
+	}
+}
+
+func (s *reassemblerCB) EventsLost(count int) {
+	logger.Errorf("lost %d auditd events during reassembly", count)
+}

--- a/internal/auditd/sessiontracker/audit_interface.go
+++ b/internal/auditd/sessiontracker/audit_interface.go
@@ -1,0 +1,9 @@
+package sessiontracker
+
+import "github.com/elastic/go-libaudit/v2/aucoalesce"
+
+// Auditor is the interface that wraps the AuditdEvent method.
+// It allows the session tracker to audit events.
+type Auditor interface {
+	AuditdEvent(event *aucoalesce.Event) error
+}

--- a/internal/auditd/sessiontracker/fakes/fakes.go
+++ b/internal/auditd/sessiontracker/fakes/fakes.go
@@ -1,0 +1,25 @@
+package fakes
+
+import (
+	"github.com/elastic/go-libaudit/v2/aucoalesce"
+
+	"github.com/metal-toolbox/audito-maldito/internal/auditd/sessiontracker"
+)
+
+var _ sessiontracker.Auditor = &FakeAuditor{}
+
+// FakeAuditor is a fake Auditor. It allows you to set a callback
+// that is called when AuditdEvent is called.
+type FakeAuditor struct {
+	cb func(event *aucoalesce.Event) error
+}
+
+func NewFakeAuditor(cb func(event *aucoalesce.Event) error) *FakeAuditor {
+	return &FakeAuditor{
+		cb: cb,
+	}
+}
+
+func (f *FakeAuditor) AuditdEvent(event *aucoalesce.Event) error {
+	return f.cb(event)
+}

--- a/internal/auditd/sessiontracker/sessiontracker.go
+++ b/internal/auditd/sessiontracker/sessiontracker.go
@@ -13,6 +13,9 @@ import (
 	"github.com/metal-toolbox/audito-maldito/internal/common"
 )
 
+// Implement Auditor interface.
+var _ Auditor = &sessionTracker{}
+
 // NewSessionTracker returns a new instance of a sessionTracker.
 func NewSessionTracker(eventWriter *auditevent.EventWriter, l *zap.SugaredLogger) *sessionTracker {
 	if l == nil {


### PR DESCRIPTION
This uses the session tracker directly in the reassembler callback in
order to remove one level of channel message passing.

To do this, the sessiontracker now introduces an interface called
`Auditor` which will output audit messages as called in a non-blocking
manner in terms of threading (it blocks on IO).

Errors are still passed to a channel, but it is now a channel just
dedicated towards errors.

A fake `Auditor` was introduced in order to allow for easier testing through
a callback function interface.