### PR TITLE
Add metrics for total of errors

### DIFF
--- a/internal/journald/reader.go
+++ b/internal/journald/reader.go
@@ -120,6 +120,8 @@ func (jp *Processor) readEntry(ctx context.Context) error {
 
 	if isNewFile == 0 {
 		if r := j.Wait(defaultSleep); r < 0 {
+			jp.Metrics.IncErrors(metrics.ErrorTypeJournaldWait)
+
 			flushLastRead(jp.CurrentTS)
 
 			logger.Errorf("wait failed after checking for new journal file, "+

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -1,0 +1,37 @@
+package metrics
+
+const (
+	// MetricsNamespace is the namespace for all metrics. This name is
+	// prepended to all metrics.
+	MetricsNamespace = "audito_maldito"
+)
+
+// LoginType is the type of login.
+type LoginType string
+
+const (
+	// SSHLogin is the login type for SSH logins.
+	SSHCertLogin LoginType = "ssh-cert"
+	// SSHKeyLogin is the login type for SSH key logins.
+	SSHKeyLogin LoginType = "ssh-key"
+	// SSHCertLogin is the login type for SSH certificate logins.
+	PasswordLogin LoginType = "password"
+	// PasswordLogin is the login type for password logins.
+	UnknownLogin LoginType = "unknown"
+)
+
+type OutcomeType string
+
+const (
+	// Success is the outcome type for successful logins.
+	Success OutcomeType = "success"
+	// Failure is the outcome type for failed logins.
+	Failure OutcomeType = "failure"
+)
+
+type ErrorType string
+
+const (
+	// ErrorTypeJournaldWait is the error type for errors waiting for journald.
+	ErrorTypeJournaldWait ErrorType = "journald_wait"
+)


### PR DESCRIPTION
This adds a metrics counter for the total of errors in audito maldito.
The metric is called `audito_maldito_errors_total`. It has a single
label called `type` which currently only picks up errors for
journald read errors. The type is hardcoded to `journald_wait`.

The guidance is that we should only add errors to this metric that we
should alert on, this way we can write proper alertmanager rules for
this.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
