### PR TITLE
Revert default logging from debug to error

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -47,7 +47,7 @@ func Run(ctx context.Context, osArgs []string, h *health.Health, optLoggerConfig
 	var auditLogDirPath string
 	var enableMetrics bool
 	var enableHealthz bool
-	logLevel := zapcore.DebugLevel // TODO: Switch default back to zapcore.ErrorLevel.
+	logLevel := zapcore.ErrorLevel
 
 	flagSet := flag.NewFlagSet(osArgs[0], flag.ContinueOnError)
 


### PR DESCRIPTION
This reverts the default logging to `error` level from `debug`.