### PR TITLE
Creates sshdprocessor struct

### DIFF
--- a/ingesters/journald/reader.go
+++ b/ingesters/journald/reader.go
@@ -37,16 +37,17 @@ func SetLogger(l *zap.SugaredLogger) {
 }
 
 type Processor struct {
-	BootID    string
-	MachineID string
-	NodeName  string
-	Distro    util.DistroType
-	EventW    *auditevent.EventWriter
-	Logins    chan<- common.RemoteUserLogin
-	CurrentTS uint64 // Microseconds since unix epoch.
-	Health    *health.Health
-	Metrics   *metrics.PrometheusMetricsProvider
-	jr        JournalReader
+	BootID        string
+	MachineID     string
+	NodeName      string
+	Distro        util.DistroType
+	EventW        *auditevent.EventWriter
+	Logins        chan<- common.RemoteUserLogin
+	CurrentTS     uint64 // Microseconds since unix epoch.
+	Health        *health.Health
+	Metrics       *metrics.PrometheusMetricsProvider
+	jr            JournalReader
+	SshdProcessor *sshd.SshdProcessor
 }
 
 func (jp *Processor) getJournalReader() JournalReader {
@@ -158,17 +159,11 @@ func (jp *Processor) readEntry(ctx context.Context) error {
 	usec := entry.GetTimeStamp()
 	jp.CurrentTS = usec
 
-	err := sshd.ProcessEntry(&sshd.ProcessEntryConfig{
-		Ctx:       ctx,
-		Logins:    jp.Logins,
-		LogEntry:  entryMsg,
-		NodeName:  jp.NodeName,
-		MachineID: jp.MachineID,
-		When:      time.UnixMicro(int64(usec)),
-		Pid:       entry.GetPID(),
-		EventW:    jp.EventW,
-		Metrics:   jp.Metrics,
+	err := jp.SshdProcessor.ProcessSshdLogEntry(ctx, sshd.SshdLogEntry{
+		Message: entryMsg,
+		PID:     entry.GetPID(),
 	})
+
 	if err != nil {
 		return fmt.Errorf("failed to process journal entry '%s': %w", entryMsg, err)
 	}

--- a/ingesters/journald/reader.go
+++ b/ingesters/journald/reader.go
@@ -163,7 +163,6 @@ func (jp *Processor) readEntry(ctx context.Context) error {
 		Message: entryMsg,
 		PID:     entry.GetPID(),
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to process journal entry '%s': %w", entryMsg, err)
 	}

--- a/processors/rocky/rockyprocessor.go
+++ b/processors/rocky/rockyprocessor.go
@@ -8,7 +8,9 @@ import (
 	sshd "github.com/metal-toolbox/audito-maldito/processors/sshd"
 )
 
-type RockyProcessor struct{}
+type RockyProcessor struct {
+	SshdProcessor *sshd.SshdProcessor
+}
 
 // pidRE regex matches a sshd log line extracting the procid and message into a match group
 // example log line:
@@ -25,15 +27,15 @@ var pidRE = regexp.MustCompile(`sshd\[(?P<PROCID>\w+)\]: (?P<MSG>.+)`)
 // numberOfMatches should have 3 match groups.
 var numberOfMatches = 3
 
-func (r *RockyProcessor) Process(ctx context.Context, line string) (sshd.ProcessEntryMessage, error) {
+func (r *RockyProcessor) Process(ctx context.Context, line string) (sshd.SshdLogEntry, error) {
 	entryMatches := pidRE.FindStringSubmatch(line)
 	if entryMatches == nil {
-		return sshd.ProcessEntryMessage{}, nil
+		return sshd.SshdLogEntry{}, nil
 	}
 
 	if len(entryMatches) < numberOfMatches {
-		return sshd.ProcessEntryMessage{}, fmt.Errorf("match group less than 3")
+		return sshd.SshdLogEntry{}, fmt.Errorf("match group less than 3")
 	}
 
-	return sshd.ProcessEntryMessage{PID: entryMatches[1], LogEntry: entryMatches[2]}, nil
+	return sshd.SshdLogEntry{PID: entryMatches[1], Message: entryMatches[2]}, nil
 }

--- a/processors/rocky/rockyprocessor_test.go
+++ b/processors/rocky/rockyprocessor_test.go
@@ -35,6 +35,6 @@ func TestRockyProcess(t *testing.T) {
 		}
 
 		assert.Equal(t, pm.PID, testSshdPid)
-		assert.Contains(t, line, pm.LogEntry)
+		assert.Contains(t, line, pm.Message)
 	}
 }

--- a/processors/sshd/sshdprocessor.go
+++ b/processors/sshd/sshdprocessor.go
@@ -13,7 +13,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/metal-toolbox/audito-maldito/internal/common"
-	"github.com/metal-toolbox/audito-maldito/processors/metrics"
+	"github.com/metal-toolbox/audito-maldito/internal/metrics"
 )
 
 func NewSshdProcessor(

--- a/processors/sshd/sshdprocessor_test.go
+++ b/processors/sshd/sshdprocessor_test.go
@@ -357,16 +357,17 @@ func TestEntryProcessing(t *testing.T) {
 			w := auditevent.NewAuditEventWriter(enc)
 
 			logins := make(chan common.RemoteUserLogin, 1)
-			err := ProcessEntry(&ProcessEntryConfig{
-				Ctx:       ctx,
-				Logins:    logins,
-				LogEntry:  tt.args.logentry,
-				NodeName:  tt.args.nodename,
-				MachineID: tt.args.mid,
-				When:      expectedts,
-				Pid:       tt.args.pid,
-				EventW:    w,
-				Metrics:   metrics.NewPrometheusMetricsProviderForRegisterer(pr),
+			pprov := metrics.NewPrometheusMetricsProviderForRegisterer(pr)
+			err := ProcessEntry(&SshdProcessor{
+				ctx:       ctx,
+				logins:    logins,
+				logEntry:  tt.args.logentry,
+				nodeName:  tt.args.nodename,
+				machineID: tt.args.mid,
+				when:      expectedts,
+				pid:       tt.args.pid,
+				eventW:    w,
+				metrics:   pprov,
 			})
 			assert.NoError(t, err)
 


### PR DESCRIPTION
    Refactors processentry to a struct named SshdProcessor.
    
    Exposes a method called ProcessSshdLogEntry that accepts a ctx
    and a SshdLogEntry to simplify waht the ingesters need to call.
    
    SshdLogEntry is a pogs (plain old go struct) that has two strings - Message and PID.