### PR TITLE
internal/health: Fix static readiness HTTP status.

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -122,21 +122,18 @@ func (o *Health) GetReadyzStatusMap() map[string]string {
 	return smap
 }
 
-func (o *Health) readyzHandler(w http.ResponseWriter, r *http.Request) {
-	smap := o.GetReadyzStatusMap()
-	if err := json.NewEncoder(w).Encode(smap); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+func (o *Health) readyzHandler(w http.ResponseWriter, _ *http.Request) {
+	status := o.GetReadyzStatusMap()
 
-	// We don't use `o.IsReady()` here we don't want to iterate
+	// We don't use `o.IsReady()` here. We don't want to iterate
 	// over the map again.
-	if smap[OverallReady] == ComponentReady {
+	if status[OverallReady] == ComponentReady {
 		w.WriteHeader(http.StatusOK)
-		return
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}
 
-	w.WriteHeader(http.StatusServiceUnavailable)
+	_ = json.NewEncoder(w).Encode(status)
 }
 
 func (o *Health) ReadyzHandler() http.Handler {


### PR DESCRIPTION
Prior to this change, the readiness HTTP endpoint would always write a HTTP 200 status code header - even if the application was not ready.

This happened because we indirectly call http.ResponseWriter.Write when we stream the readiness status map to the HTTP client. This occurs when we execute "json.NewEncoder(w).Encode(...)".

Executing http.ResponseWriter.Write results in an implicit call to http.ResponseWriter.WriteHeader, with the default value being a 200 status code. [1] Subsequent calls to WriteHeader are ignored by the http library. As a result, we were always setting the HTTP response status code header to 200. This behavior is likely meant to reflect how HTTP should work; HTTP headers are written to the peer before the body is written.

1. https://pkg.go.dev/net/http@go1.20.3#ResponseWriter