### PR TITLE
* Adds in named pipe ingesters:

### DIFF
--- a/ingesters/auditlog/auditlogingester.go
+++ b/ingesters/auditlog/auditlogingester.go
@@ -1,0 +1,31 @@
+// auditlog package processes the /var/log/audit/audit.log log file.
+// Process records the stream of text and on newline sends the line of text
+// to the AuditLogChan for received by the auditd processor for
+// correlation and analysis.
+package auditlog
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
+	"github.com/metal-toolbox/audito-maldito/internal/health"
+)
+
+type AuditLogIngester struct {
+	namedPipeIngester namedpipe.NamedPipeIngester
+	FilePath          string
+	AuditLogChan      chan string
+	Logger            *zap.SugaredLogger
+	Health            *health.Health
+}
+
+func (a *AuditLogIngester) Ingest(ctx context.Context) error {
+	return a.namedPipeIngester.Ingest(ctx, a.FilePath, '\n', a.Process, a.Logger, a.Health)
+}
+
+func (a *AuditLogIngester) Process(ctx context.Context, line string) error {
+	a.AuditLogChan <- line
+	return nil
+}

--- a/ingesters/auditlog/auditlogingester.go
+++ b/ingesters/auditlog/auditlogingester.go
@@ -7,22 +7,29 @@ package auditlog
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
-	"github.com/metal-toolbox/audito-maldito/internal/health"
 )
+
+func NewAuditLogIngester(
+	filePath string,
+	auditLogChan chan string,
+	namedPipeIngester namedpipe.NamedPipeIngester,
+) AuditLogIngester {
+	return AuditLogIngester{
+		FilePath:          filePath,
+		AuditLogChan:      auditLogChan,
+		namedPipeIngester: namedPipeIngester,
+	}
+}
 
 type AuditLogIngester struct {
 	namedPipeIngester namedpipe.NamedPipeIngester
 	FilePath          string
 	AuditLogChan      chan string
-	Logger            *zap.SugaredLogger
-	Health            *health.Health
 }
 
 func (a *AuditLogIngester) Ingest(ctx context.Context) error {
-	return a.namedPipeIngester.Ingest(ctx, a.FilePath, '\n', a.Process, a.Logger, a.Health)
+	return a.namedPipeIngester.Ingest(ctx, a.FilePath, '\n', a.Process)
 }
 
 func (a *AuditLogIngester) Process(ctx context.Context, line string) error {

--- a/ingesters/auditlog/auditlogingester_test.go
+++ b/ingesters/auditlog/auditlogingester_test.go
@@ -1,0 +1,74 @@
+package auditlog_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/metal-toolbox/audito-maldito/ingesters/auditlog"
+	"github.com/metal-toolbox/audito-maldito/internal/health"
+	"github.com/stretchr/testify/assert"
+
+	"go.uber.org/zap"
+)
+
+func TestIngest(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "")
+	pipePath := fmt.Sprintf("%s/audit-pipe", tmpDir)
+	defer func() {
+		os.RemoveAll(tmpDir)
+	}()
+	err = syscall.Mkfifo(pipePath, 0664)
+	if err != nil {
+		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
+	}
+
+	auditLogChanBufSize := 10000
+	auditLogChan := make(chan string, auditLogChanBufSize)
+	sugar := zap.NewExample().Sugar()
+	h := health.NewSingleReadinessHealth("auditlog")
+	alp := auditlog.AuditLogIngester{
+		FilePath:     pipePath,
+		AuditLogChan: auditLogChan,
+		Logger:       sugar,
+		Health:       h,
+	}
+
+	ctx := context.Background()
+	go func() {
+		alp.Ingest(ctx)
+	}()
+
+	go func() {
+		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
+		log.Println("opened Pipe for writing")
+		if err != nil {
+			t.Errorf("failed to initialize tests: Could not open %s named pipe", pipePath)
+		}
+
+		for range []int{0, 1, 2, 3, 4} {
+			_, err := file.WriteString("foo bar\n")
+			log.Println("writing")
+
+			if err != nil {
+				t.Errorf("error writing to pipe %s", pipePath)
+			}
+		}
+	}()
+
+	readCount := 0
+	for {
+		select {
+		case line := <-auditLogChan:
+			assert.Equal(t, "foo bar\n", line)
+			readCount++
+		}
+
+		if readCount == 5 {
+			break
+		}
+	}
+}

--- a/ingesters/auditlog/auditlogingester_test.go
+++ b/ingesters/auditlog/auditlogingester_test.go
@@ -7,11 +7,11 @@ import (
 	"syscall"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/metal-toolbox/audito-maldito/ingesters/auditlog"
 	"github.com/metal-toolbox/audito-maldito/internal/health"
 	"github.com/stretchr/testify/assert"
-
-	"go.uber.org/zap"
 )
 
 func TestIngest(t *testing.T) {

--- a/ingesters/auditlog/auditlogingester_test.go
+++ b/ingesters/auditlog/auditlogingester_test.go
@@ -16,16 +16,13 @@ import (
 
 func TestIngest(t *testing.T) {
 	t.Parallel()
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Errorf("failed to initialize tests: Could not create %s dir", tmpDir)
-	}
+	tmpDir := t.TempDir()
 
 	pipePath := fmt.Sprintf("%s/audit-pipe", tmpDir)
 	defer func() {
 		os.RemoveAll(tmpDir)
 	}()
-	err = syscall.Mkfifo(pipePath, 0o664)
+	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
 		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}

--- a/ingesters/auditlog/auditlogingester_test.go
+++ b/ingesters/auditlog/auditlogingester_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestIngest(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "")
 	pipePath := fmt.Sprintf("%s/audit-pipe", tmpDir)
 	defer func() {

--- a/ingesters/auditlog/auditlogingester_test.go
+++ b/ingesters/auditlog/auditlogingester_test.go
@@ -21,9 +21,7 @@ func TestIngest(t *testing.T) {
 
 	pipePath := fmt.Sprintf("%s/audit-pipe", tmpDir)
 	err := syscall.Mkfifo(pipePath, 0o664)
-	if err != nil {
-		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
-	}
+	assert.NoError(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 
 	auditLogChanBufSize := 10000
 	auditLogChan := make(chan string, auditLogChanBufSize)
@@ -46,15 +44,11 @@ func TestIngest(t *testing.T) {
 
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
-		if err != nil {
-			assert.Error(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
-		}
+		assert.NoError(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString("foo bar\n")
-			if err != nil {
-				assert.Error(t, err, "error writing to pipe %s", pipePath)
-			}
+			assert.NoError(t, err, "error writing to pipe %s", pipePath)
 		}
 	}()
 

--- a/ingesters/auditlog/auditlogingester_test.go
+++ b/ingesters/auditlog/auditlogingester_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/metal-toolbox/audito-maldito/ingesters/auditlog"
+	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
 	"github.com/metal-toolbox/audito-maldito/internal/health"
 )
 
@@ -29,14 +30,14 @@ func TestIngest(t *testing.T) {
 
 	auditLogChanBufSize := 10000
 	auditLogChan := make(chan string, auditLogChanBufSize)
-	sugar := zap.NewExample().Sugar()
+	logger := zap.NewExample().Sugar()
 	h := health.NewSingleReadinessHealth("auditlog")
-	ali := auditlog.AuditLogIngester{
-		FilePath:     pipePath,
-		AuditLogChan: auditLogChan,
-		Logger:       sugar,
-		Health:       h,
-	}
+	namedPipeIngester := namedpipe.NewNamedPipeIngester(logger, h)
+	ali := auditlog.NewAuditLogIngester(
+		pipePath,
+		auditLogChan,
+		namedPipeIngester,
+	)
 
 	ctx := context.Background()
 	go func() {

--- a/ingesters/auditlog/auditlogingester_test.go
+++ b/ingesters/auditlog/auditlogingester_test.go
@@ -24,7 +24,7 @@ func TestIngest(t *testing.T) {
 	}()
 	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
-		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
+		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}
 
 	auditLogChanBufSize := 10000
@@ -49,13 +49,13 @@ func TestIngest(t *testing.T) {
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
 		if err != nil {
-			t.Errorf("failed to initialize tests: Could not open %s named pipe", pipePath)
+			assert.Error(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
 		}
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString("foo bar\n")
 			if err != nil {
-				t.Errorf("error writing to pipe %s", pipePath)
+				assert.Error(t, err, "error writing to pipe %s", pipePath)
 			}
 		}
 	}()

--- a/ingesters/auditlog/auditlogingester_test.go
+++ b/ingesters/auditlog/auditlogingester_test.go
@@ -20,9 +20,6 @@ func TestIngest(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	pipePath := fmt.Sprintf("%s/audit-pipe", tmpDir)
-	defer func() {
-		os.RemoveAll(tmpDir)
-	}()
 	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
 		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)

--- a/ingesters/journald/reader.go
+++ b/ingesters/journald/reader.go
@@ -47,7 +47,7 @@ type Processor struct {
 	Health        *health.Health
 	Metrics       *metrics.PrometheusMetricsProvider
 	jr            JournalReader
-	SshdProcessor *sshd.SshdProcessor
+	SshdProcessor sshd.SshdProcessor
 }
 
 func (jp *Processor) getJournalReader() JournalReader {

--- a/ingesters/namedpipe/namedpipeingester.go
+++ b/ingesters/namedpipe/namedpipeingester.go
@@ -3,7 +3,6 @@ package namedpipe
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"os"
 
 	"go.uber.org/zap"
@@ -60,12 +59,7 @@ func (n *NamedPipeIngester) Ingest(
 	n.Logger.Infof("Successfully opened %s", filePath)
 	defer file.Close()
 
-	fileInfo, err := os.Stat(filePath)
-	if err != nil {
-		return err
-	}
-
-	n.Health.OnReady(fmt.Sprintf("%s-%s", fileInfo.Name(), NamedPipeProcessorComponentName))
+	n.Health.OnReady(NamedPipeProcessorComponentName)
 	r := bufio.NewReader(file)
 
 	for {

--- a/ingesters/namedpipe/namedpipeingester.go
+++ b/ingesters/namedpipe/namedpipeingester.go
@@ -45,11 +45,12 @@ func (n *NamedPipeIngester) Ingest(
 	case <-ready:
 	}
 
-	logger.Infof("Successfully opened %s", filePath)
-
 	if err != nil {
 		return err
 	}
+
+	logger.Infof("Successfully opened %s", filePath)
+	defer file.Close()
 
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
@@ -58,10 +59,6 @@ func (n *NamedPipeIngester) Ingest(
 
 	h.OnReady(fmt.Sprintf("%s-%s", fileInfo.Name(), NamedPipeProcessorComponentName))
 	r := bufio.NewReader(file)
-	go (func() {
-		<-ctx.Done()
-		file.Close()
-	})()
 
 	for {
 		line, err := r.ReadString(delim)

--- a/ingesters/namedpipe/namedpipeingester.go
+++ b/ingesters/namedpipe/namedpipeingester.go
@@ -1,0 +1,77 @@
+package namedpipe
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+
+	"github.com/metal-toolbox/audito-maldito/internal/health"
+)
+
+const (
+	// NamedPipeProcessorComponentName is the name of the component
+	// that reads from a named pipe. This is used in the health check.
+	NamedPipeProcessorComponentName = "named-pipe-processor"
+)
+
+type NamedPipeIngester struct{}
+
+type Callback func(context.Context, string) error
+
+func (n *NamedPipeIngester) Ingest(
+	ctx context.Context,
+	filePath string,
+	delim byte,
+	callback Callback,
+	logger *zap.SugaredLogger,
+	h *health.Health,
+) error {
+	var file *os.File
+	var err error
+	ready := make(chan struct{})
+
+	// os.OpenFile blocks. Put in go routine so we can gracefully exit.
+	go func() {
+		file, err = os.OpenFile(filePath, os.O_RDONLY, os.ModeNamedPipe)
+		close(ready)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ready:
+	}
+
+	logger.Infof("Successfully opened %s", filePath)
+
+	if err != nil {
+		return err
+	}
+
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+
+	h.OnReady(fmt.Sprintf("%s-%s", fileInfo.Name(), NamedPipeProcessorComponentName))
+	r := bufio.NewReader(file)
+	go (func() {
+		<-ctx.Done()
+		file.Close()
+	})()
+
+	for {
+		line, err := r.ReadString(delim)
+		if err != nil {
+			logger.Errorf("error reading from ", file.Name())
+			return err
+		}
+		err = callback(ctx, line)
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -24,7 +24,7 @@ func TestIngest(t *testing.T) {
 	}()
 	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
-		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
+		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}
 
 	sugar := zap.NewExample().Sugar()
@@ -53,13 +53,13 @@ func TestIngest(t *testing.T) {
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
 		if err != nil {
-			t.Errorf("failed to initialize tests: Could not open %s named pipe", pipePath)
+			assert.Error(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
 		}
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString("foo bar\n")
 			if err != nil {
-				t.Errorf("error writing to pipe %s", pipePath)
+				assert.Error(t, err, "error writing to pipe %s", pipePath)
 			}
 		}
 	}()

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -19,9 +19,6 @@ func TestIngest(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/named-pipe", tmpDir)
-	defer func() {
-		os.RemoveAll(tmpDir)
-	}()
 	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
 		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestIngest(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := os.MkdirTemp("", "")
 	pipePath := fmt.Sprintf("%s/named-pipe", tmpDir)
 	defer func() {

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -25,7 +25,7 @@ func TestIngest(t *testing.T) {
 	}
 
 	logger := zap.NewExample().Sugar()
-	h := health.NewSingleReadinessHealth("namedpipe")
+	h := health.NewSingleReadinessHealth(namedpipe.NamedPipeProcessorComponentName)
 	np := namedpipe.NewNamedPipeIngester(logger, h)
 
 	ctx := context.Background()

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -27,9 +27,9 @@ func TestIngest(t *testing.T) {
 		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}
 
-	sugar := zap.NewExample().Sugar()
+	logger := zap.NewExample().Sugar()
 	h := health.NewSingleReadinessHealth("namedpipe")
-	np := namedpipe.NamedPipeIngester{}
+	np := namedpipe.NewNamedPipeIngester(logger, h)
 
 	ctx := context.Background()
 	callCount := 0
@@ -44,7 +44,7 @@ func TestIngest(t *testing.T) {
 		return nil
 	}
 	go func() {
-		err := np.Ingest(ctx, pipePath, '\n', callback, sugar, h)
+		err := np.Ingest(ctx, pipePath, '\n', callback)
 		if err != nil {
 			return
 		}

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -20,9 +20,7 @@ func TestIngest(t *testing.T) {
 	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/named-pipe", tmpDir)
 	err := syscall.Mkfifo(pipePath, 0o664)
-	if err != nil {
-		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
-	}
+	assert.NoError(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 
 	logger := zap.NewExample().Sugar()
 	h := health.NewSingleReadinessHealth(namedpipe.NamedPipeProcessorComponentName)
@@ -49,15 +47,11 @@ func TestIngest(t *testing.T) {
 
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
-		if err != nil {
-			assert.Error(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
-		}
+		assert.NoError(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString("foo bar\n")
-			if err != nil {
-				assert.Error(t, err, "error writing to pipe %s", pipePath)
-			}
+			assert.NoError(t, err, "error writing to pipe %s", pipePath)
 		}
 	}()
 

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -17,16 +17,12 @@ import (
 func TestIngest(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Errorf("failed to initialize tests: Could not create %s dir", tmpDir)
-	}
-
+	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/named-pipe", tmpDir)
 	defer func() {
 		os.RemoveAll(tmpDir)
 	}()
-	err = syscall.Mkfifo(pipePath, 0o664)
+	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
 		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -1,0 +1,66 @@
+package namedpipe_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
+	"github.com/metal-toolbox/audito-maldito/internal/health"
+	"github.com/stretchr/testify/assert"
+
+	"go.uber.org/zap"
+)
+
+func TestIngest(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "")
+	pipePath := fmt.Sprintf("%s/named-pipe", tmpDir)
+	defer func() {
+		os.RemoveAll(tmpDir)
+	}()
+	err = syscall.Mkfifo(pipePath, 0664)
+	if err != nil {
+		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
+	}
+
+	sugar := zap.NewExample().Sugar()
+	h := health.NewSingleReadinessHealth("namedpipe")
+	np := namedpipe.NamedPipeIngester{}
+
+	ctx := context.Background()
+	callCount := 0
+	done := make(chan struct{})
+	callback := func(ctx context.Context, l string) error {
+		callCount++
+		if callCount == 5 {
+			done <- struct{}{}
+		}
+		return nil
+	}
+	go func() {
+		np.Ingest(ctx, pipePath, '\n', callback, sugar, h)
+	}()
+
+	go func() {
+		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
+		log.Println("opened Pipe for writing")
+		if err != nil {
+			t.Errorf("failed to initialize tests: Could not open %s named pipe", pipePath)
+		}
+
+		for range []int{0, 1, 2, 3, 4} {
+			_, err := file.WriteString("foo bar\n")
+			log.Println("writing")
+
+			if err != nil {
+				t.Errorf("error writing to pipe %s", pipePath)
+			}
+		}
+	}()
+
+	<-done
+	assert.Equal(t, 5, callCount)
+}

--- a/ingesters/namedpipe/namedpipeingester_test.go
+++ b/ingesters/namedpipe/namedpipeingester_test.go
@@ -3,7 +3,6 @@ package namedpipe_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"syscall"
 	"testing"
@@ -46,15 +45,12 @@ func TestIngest(t *testing.T) {
 
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
-		log.Println("opened Pipe for writing")
 		if err != nil {
 			t.Errorf("failed to initialize tests: Could not open %s named pipe", pipePath)
 		}
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString("foo bar\n")
-			log.Println("writing")
-
 			if err != nil {
 				t.Errorf("error writing to pipe %s", pipePath)
 			}

--- a/ingesters/rocky/fakes/sshdporcessorfaker.go
+++ b/ingesters/rocky/fakes/sshdporcessorfaker.go
@@ -1,0 +1,27 @@
+package fakes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/metal-toolbox/audito-maldito/processors/sshd"
+)
+
+type SshdProcessorFaker struct {
+	CountChan   chan int
+	count       int
+	ExpectedPID string
+}
+
+func (s *SshdProcessorFaker) ProcessSshdLogEntry(ctx context.Context, sm sshd.SshdLogEntry) error {
+	s.count += 1
+	s.CountChan <- s.count
+	if len(sm.Message) < 1 {
+		return fmt.Errorf("message should be greater than 1")
+	}
+
+	if sm.PID != s.ExpectedPID {
+		return fmt.Errorf("expected PID should be %s", s.ExpectedPID)
+	}
+	return nil
+}

--- a/ingesters/rocky/rockyingester.go
+++ b/ingesters/rocky/rockyingester.go
@@ -1,0 +1,57 @@
+package rocky
+
+import (
+	"context"
+	"regexp"
+
+	"go.uber.org/zap"
+
+	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
+	"github.com/metal-toolbox/audito-maldito/internal/health"
+	"github.com/metal-toolbox/audito-maldito/processors/sshd"
+)
+
+type RockyIngester struct {
+	namedPipeIngester namedpipe.NamedPipeIngester
+	FilePath          string
+	SshdProcessor     sshd.SshdProcessor
+	Logger            *zap.SugaredLogger
+	Health            *health.Health
+}
+
+func (r *RockyIngester) Ingest(ctx context.Context) error {
+	return r.namedPipeIngester.Ingest(ctx, r.FilePath, '\n', r.Process, r.Logger, r.Health)
+}
+
+func (r *RockyIngester) Process(ctx context.Context, line string) error {
+	sm := r.ParseRockySecureMessage(line)
+	return r.SshdProcessor.ProcessSshdLogEntry(ctx, sm)
+}
+
+// pidRE regex matches a sshd log line extracting the procid and message into a match group
+// example log line:
+//
+//	Apr  3 15:48:03 localhost sshd[3894]: Connection closed by authenticating user user 127.0.0.1 port 41796 [preauth]
+//
+// regex match:
+//
+//	entryMatches[0]: sshd[3894]: Connection closed by authenticating user user 127.0.0.1 port 41796 [preauth]
+//	entryMatches[1]: 3894
+//	entryMatches[2]: Connection closed by authenticating user user 127.0.0.1 port 41796 [preauth]
+var pidRE = regexp.MustCompile(`sshd\[(?P<PROCID>\w+)\]: (?P<MSG>.+)`)
+
+// numberOfMatches should have 3 match groups.
+var numberOfMatches = 3
+
+func (r *RockyIngester) ParseRockySecureMessage(line string) sshd.SshdLogEntry {
+	messageMatches := pidRE.FindStringSubmatch(line)
+	if messageMatches == nil {
+		return sshd.SshdLogEntry{}
+	}
+
+	if len(messageMatches) < numberOfMatches {
+		return sshd.SshdLogEntry{}
+	}
+
+	return sshd.SshdLogEntry{PID: messageMatches[1], Message: messageMatches[2]}
+}

--- a/ingesters/rocky/rockyingester.go
+++ b/ingesters/rocky/rockyingester.go
@@ -14,7 +14,7 @@ import (
 type RockyIngester struct {
 	namedPipeIngester namedpipe.NamedPipeIngester
 	FilePath          string
-	SshdProcessor     sshd.SshdProcessor
+	SshdProcessor     sshd.SshdProcessorer
 	Logger            *zap.SugaredLogger
 	Health            *health.Health
 }

--- a/ingesters/rocky/rockyingester.go
+++ b/ingesters/rocky/rockyingester.go
@@ -14,7 +14,7 @@ import (
 type RockyIngester struct {
 	namedPipeIngester namedpipe.NamedPipeIngester
 	FilePath          string
-	SshdProcessor     sshd.SshdProcessorer
+	SshdProcessor     sshd.SshdProcessor
 	Logger            *zap.SugaredLogger
 	Health            *health.Health
 }

--- a/ingesters/rocky/rockyingester.go
+++ b/ingesters/rocky/rockyingester.go
@@ -4,23 +4,30 @@ import (
 	"context"
 	"regexp"
 
-	"go.uber.org/zap"
-
 	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
-	"github.com/metal-toolbox/audito-maldito/internal/health"
 	"github.com/metal-toolbox/audito-maldito/processors/sshd"
 )
+
+func NewRockyIngester(
+	filePath string,
+	sshdProcessor sshd.SshdProcessor,
+	namedPipeIngester namedpipe.NamedPipeIngester,
+) RockyIngester {
+	return RockyIngester{
+		FilePath:          filePath,
+		SshdProcessor:     sshdProcessor,
+		namedPipeIngester: namedPipeIngester,
+	}
+}
 
 type RockyIngester struct {
 	namedPipeIngester namedpipe.NamedPipeIngester
 	FilePath          string
 	SshdProcessor     sshd.SshdProcessor
-	Logger            *zap.SugaredLogger
-	Health            *health.Health
 }
 
 func (r *RockyIngester) Ingest(ctx context.Context) error {
-	return r.namedPipeIngester.Ingest(ctx, r.FilePath, '\n', r.Process, r.Logger, r.Health)
+	return r.namedPipeIngester.Ingest(ctx, r.FilePath, '\n', r.Process)
 }
 
 func (r *RockyIngester) Process(ctx context.Context, line string) error {

--- a/ingesters/rocky/rockyingester_test.go
+++ b/ingesters/rocky/rockyingester_test.go
@@ -48,9 +48,7 @@ func TestIngest(t *testing.T) {
 	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/secure-pipe", tmpDir)
 	err := syscall.Mkfifo(pipePath, 0o664)
-	if err != nil {
-		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
-	}
+	assert.NoError(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	countChan := make(chan int)
 	expectedPID := "10"
 	h := health.NewSingleReadinessHealth("secure")
@@ -72,15 +70,11 @@ func TestIngest(t *testing.T) {
 
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
-		if err != nil {
-			assert.Error(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
-		}
+		assert.NoError(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString(fmt.Sprintf("sshd[%s]:", expectedPID) + " foo bar\n")
-			if err != nil {
-				assert.Error(t, err, "error writing to pipe %s", pipePath)
-			}
+			assert.NoError(t, err, "error writing to pipe %s", pipePath)
 		}
 	}()
 

--- a/ingesters/rocky/rockyingester_test.go
+++ b/ingesters/rocky/rockyingester_test.go
@@ -44,17 +44,13 @@ func TestRockyProcess(t *testing.T) {
 func TestIngest(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Errorf("failed to initialize tests: Could not create %s dir", tmpDir)
-	}
-
+	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/secure-pipe", tmpDir)
 
 	defer func() {
 		os.RemoveAll(tmpDir)
 	}()
-	err = syscall.Mkfifo(pipePath, 0o664)
+	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
 		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}

--- a/ingesters/rocky/rockyingester_test.go
+++ b/ingesters/rocky/rockyingester_test.go
@@ -42,6 +42,8 @@ func TestRockyProcess(t *testing.T) {
 }
 
 func TestIngest(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := os.MkdirTemp("", "")
 	pipePath := fmt.Sprintf("%s/secure-pipe", tmpDir)
 

--- a/ingesters/rocky/rockyingester_test.go
+++ b/ingesters/rocky/rockyingester_test.go
@@ -47,10 +47,6 @@ func TestIngest(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/secure-pipe", tmpDir)
-
-	defer func() {
-		os.RemoveAll(tmpDir)
-	}()
 	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
 		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)

--- a/ingesters/rocky/rockyingester_test.go
+++ b/ingesters/rocky/rockyingester_test.go
@@ -1,0 +1,35 @@
+package rocky_test
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/metal-toolbox/audito-maldito/ingesters/rocky"
+)
+
+//go:embed testdata/secure.log
+var secureLogs string
+
+// testSshdPid is the pid used in our test files.
+var testSshdPid = "3894"
+
+func TestRockyProcess(t *testing.T) {
+	t.Parallel()
+	r := rocky.RockyIngester{}
+	for _, line := range strings.Split(secureLogs, "\n") {
+		logEntry := r.ParseRockySecureMessage(line)
+		if logEntry.PID == "" {
+			continue
+		}
+
+		if logEntry.Message == "" {
+			continue
+		}
+
+		assert.Equal(t, logEntry.PID, testSshdPid)
+		assert.Contains(t, line, logEntry.Message)
+	}
+}

--- a/ingesters/rocky/rockyingester_test.go
+++ b/ingesters/rocky/rockyingester_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
 	"github.com/metal-toolbox/audito-maldito/ingesters/rocky"
 	"github.com/metal-toolbox/audito-maldito/ingesters/rocky/fakes"
 	"github.com/metal-toolbox/audito-maldito/internal/health"
@@ -57,16 +58,15 @@ func TestIngest(t *testing.T) {
 	countChan := make(chan int)
 	expectedPID := "10"
 	h := health.NewSingleReadinessHealth("secure")
-	sugar := zap.NewExample().Sugar()
+	logger := zap.NewExample().Sugar()
+	namedPipeIngester := namedpipe.NewNamedPipeIngester(logger, h)
+	ri := rocky.NewRockyIngester(
+		pipePath,
+		&fakes.SshdProcessorFaker{CountChan: countChan, ExpectedPID: expectedPID},
+		namedPipeIngester,
+	)
 
 	ctx := context.Background()
-	ri := rocky.RockyIngester{
-		FilePath:      pipePath,
-		SshdProcessor: &fakes.SshdProcessorFaker{CountChan: countChan, ExpectedPID: expectedPID},
-		Logger:        sugar,
-		Health:        h,
-	}
-
 	go func() {
 		err := ri.Ingest(ctx)
 		if err != nil {

--- a/ingesters/rocky/rockyingester_test.go
+++ b/ingesters/rocky/rockyingester_test.go
@@ -52,7 +52,7 @@ func TestIngest(t *testing.T) {
 	}()
 	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
-		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
+		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}
 	countChan := make(chan int)
 	expectedPID := "10"
@@ -77,13 +77,13 @@ func TestIngest(t *testing.T) {
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
 		if err != nil {
-			t.Errorf("failed to initialize tests: Could not open %s named pipe", pipePath)
+			assert.Error(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
 		}
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString(fmt.Sprintf("sshd[%s]:", expectedPID) + " foo bar\n")
 			if err != nil {
-				t.Errorf("error writing to pipe %s", pipePath)
+				assert.Error(t, err, "error writing to pipe %s", pipePath)
 			}
 		}
 	}()

--- a/ingesters/rocky/testdata/secure.log
+++ b/ingesters/rocky/testdata/secure.log
@@ -1,0 +1,40 @@
+Apr  3 15:46:48 localhost sudo[3819]:    user : TTY=pts/0 ; PWD=/home/user ; USER=root ; COMMAND=/sbin/rsyslogd -iNONE -n -f /home/user/rsyslog.conf
+Apr  3 15:46:48 localhost sudo[3819]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=1000)
+Apr  3 15:47:42 localhost unix_chkpwd[3898]: password check failed for user (user)
+Apr  3 15:47:42 localhost sshd[3894]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=127.0.0.1  user=user
+Apr  3 15:47:44 localhost sshd[3894]: Failed password for user from 127.0.0.1 port 41796 ssh2
+Apr  3 15:47:53 localhost unix_chkpwd[3920]: password check failed for user (user)
+Apr  3 15:47:55 localhost sshd[3894]: Failed password for user from 127.0.0.1 port 41796 ssh2
+Apr  3 15:48:00 localhost unix_chkpwd[3922]: password check failed for user (user)
+Apr  3 15:48:02 localhost sshd[3894]: Failed password for user from 127.0.0.1 port 41796 ssh2
+Apr  3 15:48:03 localhost sshd[3894]: Connection closed by authenticating user user 127.0.0.1 port 41796 [preauth]
+Apr  3 15:48:03 localhost sshd[3894]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=127.0.0.1  user=user
+Apr  3 15:49:11 localhost sudo[3819]: pam_unix(sudo:session): session closed for user root
+Apr  3 15:49:21 localhost sudo[3936]:    user : TTY=pts/0 ; PWD=/home/user ; USER=root ; COMMAND=/sbin/rsyslogd -iNONE -n -f /home/user/rsyslog.conf
+Apr  3 15:49:21 localhost sudo[3936]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=1000)
+Apr  3 15:49:38 localhost unix_chkpwd[3951]: password check failed for user (user)
+Apr  3 15:50:13 localhost sudo[3936]: pam_unix(sudo:session): session closed for user root
+Apr  4 08:36:07 localhost polkitd[881]: Loading rules from directory /etc/polkit-1/rules.d
+Apr  4 08:36:07 localhost polkitd[881]: Loading rules from directory /usr/share/polkit-1/rules.d
+Apr  4 08:36:07 localhost polkitd[881]: Finished loading, compiling and executing 11 rules
+Apr  4 08:36:07 localhost polkitd[881]: Acquired the name org.freedesktop.PolicyKit1 on the system bus
+Apr  4 08:36:07 localhost useradd[1027]: failed adding user 'vboxadd', exit code: 9
+Apr  4 08:36:07 localhost useradd[1036]: failed adding user 'vboxadd', exit code: 9
+Apr  4 08:36:08 localhost systemd[1833]: pam_unix(systemd-user:session): session opened for user gdm(uid=42) by (uid=0)
+Apr  4 08:36:09 localhost gdm-launch-environment][1828]: pam_unix(gdm-launch-environment:session): session opened for user gdm(uid=42) by (uid=0)
+Apr  4 08:36:09 localhost polkitd[881]: Registered Authentication Agent for unix-session:c1 (system bus name :1.26 [/usr/bin/gnome-shell], object path /org/freedesktop/PolicyKit1/AuthenticationAgent, locale en_US.UTF-8)
+Apr  4 08:36:17 localhost gdm-password][2269]: gkr-pam: unable to locate daemon control file
+Apr  4 08:36:17 localhost gdm-password][2269]: gkr-pam: stashed password to try later in open session
+Apr  4 08:36:17 localhost systemd[2284]: pam_unix(systemd-user:session): session opened for user user(uid=1000) by (uid=0)
+Apr  4 08:36:17 localhost gdm-password][2269]: pam_unix(gdm-password:session): session opened for user user(uid=1000) by (uid=0)
+Apr  4 08:36:17 localhost gdm-password][2269]: gkr-pam: gnome-keyring-daemon started properly and unlocked keyring
+Apr  4 08:36:18 localhost polkitd[881]: Registered Authentication Agent for unix-session:2 (system bus name :1.69 [/usr/bin/gnome-shell], object path /org/freedesktop/PolicyKit1/AuthenticationAgent, locale en_US.UTF-8)
+Apr  4 08:36:20 localhost gdm-launch-environment][1828]: pam_unix(gdm-launch-environment:session): session closed for user gdm
+Apr  4 08:36:20 localhost polkitd[881]: Unregistered Authentication Agent for unix-session:c1 (system bus name :1.26, object path /org/freedesktop/PolicyKit1/AuthenticationAgent, locale en_US.UTF-8) (disconnected from bus)
+Apr  4 08:42:40 localhost gdm-password][3542]: gkr-pam: unlocked login keyring
+Apr  4 08:43:32 localhost sudo[3615]:    user : TTY=pts/0 ; PWD=/run/systemd/journal ; USER=root ; COMMAND=/bin/setfacl -m u:1000:rwx -R .
+Apr  4 08:43:32 localhost sudo[3615]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=1000)
+Apr  4 08:43:32 localhost sudo[3615]: pam_unix(sudo:session): session closed for user root
+Apr  4 08:44:06 localhost sudo[3691]:    user : TTY=pts/0 ; PWD=/home/user ; USER=root ; COMMAND=/sbin/rsyslogd -n -f rsyslog.conf
+Apr  4 08:44:06 localhost sudo[3691]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=1000)
+Apr  4 08:44:37 localhost sudo[3691]: pam_unix(sudo:session): session  closed for user root

--- a/ingesters/syslog/fakes/sshdporcessorfaker.go
+++ b/ingesters/syslog/fakes/sshdporcessorfaker.go
@@ -1,0 +1,27 @@
+package fakes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/metal-toolbox/audito-maldito/processors/sshd"
+)
+
+type SshdProcessorFaker struct {
+	CountChan   chan int
+	count       int
+	ExpectedPID string
+}
+
+func (s *SshdProcessorFaker) ProcessSshdLogEntry(ctx context.Context, sm sshd.SshdLogEntry) error {
+	s.count += 1
+	s.CountChan <- s.count
+	if len(sm.Message) < 1 {
+		return fmt.Errorf("message should be greater than 1")
+	}
+
+	if sm.PID != s.ExpectedPID {
+		return fmt.Errorf("expected PID should be %s", s.ExpectedPID)
+	}
+	return nil
+}

--- a/ingesters/syslog/syslogingester.go
+++ b/ingesters/syslog/syslogingester.go
@@ -4,23 +4,30 @@ import (
 	"context"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
-	"github.com/metal-toolbox/audito-maldito/internal/health"
 	"github.com/metal-toolbox/audito-maldito/processors/sshd"
 )
+
+func NewSyslogIngester(
+	filePath string,
+	sshdProcessor sshd.SshdProcessor,
+	namedPipeIngester namedpipe.NamedPipeIngester,
+) SyslogIngester {
+	return SyslogIngester{
+		FilePath:          filePath,
+		SshdProcessor:     sshdProcessor,
+		namedPipeIngester: namedPipeIngester,
+	}
+}
 
 type SyslogIngester struct {
 	namedPipeIngester namedpipe.NamedPipeIngester
 	FilePath          string
 	SshdProcessor     sshd.SshdProcessor
-	Logger            *zap.SugaredLogger
-	Health            *health.Health
 }
 
 func (s *SyslogIngester) Ingest(ctx context.Context) error {
-	return s.namedPipeIngester.Ingest(ctx, s.FilePath, '\n', s.Process, s.Logger, s.Health)
+	return s.namedPipeIngester.Ingest(ctx, s.FilePath, '\n', s.Process)
 }
 
 func (s *SyslogIngester) Process(ctx context.Context, line string) error {

--- a/ingesters/syslog/syslogingester.go
+++ b/ingesters/syslog/syslogingester.go
@@ -28,11 +28,15 @@ func (s *SyslogIngester) Process(ctx context.Context, line string) error {
 	return s.SshdProcessor.ProcessSshdLogEntry(ctx, sm)
 }
 
+// ParseSyslogMessage expects a message in the form of "<PID> <Message>".
 func (s *SyslogIngester) ParseSyslogMessage(entry string) sshd.SshdLogEntry {
+	minimumEntrySplitLength := 2
 	entrySplit := strings.Split(entry, " ")
-	if len(entrySplit) < 2 {
+
+	if len(entrySplit) < minimumEntrySplitLength {
 		return sshd.SshdLogEntry{}
 	}
+
 	pid := entrySplit[0]
 	logMsg := strings.Join(entrySplit[1:], " ")
 	logMsg = strings.TrimLeft(logMsg, " ")

--- a/ingesters/syslog/syslogingester.go
+++ b/ingesters/syslog/syslogingester.go
@@ -30,6 +30,9 @@ func (s *SyslogIngester) Process(ctx context.Context, line string) error {
 
 func (s *SyslogIngester) ParseSyslogMessage(entry string) sshd.SshdLogEntry {
 	entrySplit := strings.Split(entry, " ")
+	if len(entrySplit) < 2 {
+		return sshd.SshdLogEntry{}
+	}
 	pid := entrySplit[0]
 	logMsg := strings.Join(entrySplit[1:], " ")
 	logMsg = strings.TrimLeft(logMsg, " ")

--- a/ingesters/syslog/syslogingester.go
+++ b/ingesters/syslog/syslogingester.go
@@ -1,0 +1,37 @@
+package syslog
+
+import (
+	"context"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/metal-toolbox/audito-maldito/ingesters/namedpipe"
+	"github.com/metal-toolbox/audito-maldito/internal/health"
+	"github.com/metal-toolbox/audito-maldito/processors/sshd"
+)
+
+type SyslogIngester struct {
+	namedPipeIngester namedpipe.NamedPipeIngester
+	FilePath          string
+	SshdProcessor     sshd.SshdProcessor
+	Logger            *zap.SugaredLogger
+	Health            *health.Health
+}
+
+func (s *SyslogIngester) Ingest(ctx context.Context) error {
+	return s.namedPipeIngester.Ingest(ctx, s.FilePath, '\n', s.Process, s.Logger, s.Health)
+}
+
+func (s *SyslogIngester) Process(ctx context.Context, line string) error {
+	sm := s.ParseSyslogMessage(line)
+	return s.SshdProcessor.ProcessSshdLogEntry(ctx, sm)
+}
+
+func (s *SyslogIngester) ParseSyslogMessage(entry string) sshd.SshdLogEntry {
+	entrySplit := strings.Split(entry, " ")
+	pid := entrySplit[0]
+	logMsg := strings.Join(entrySplit[1:], " ")
+	logMsg = strings.TrimLeft(logMsg, " ")
+	return sshd.SshdLogEntry{PID: pid, Message: logMsg}
+}

--- a/ingesters/syslog/syslogingester_test.go
+++ b/ingesters/syslog/syslogingester_test.go
@@ -7,11 +7,11 @@ import (
 	"syscall"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/metal-toolbox/audito-maldito/ingesters/syslog"
 	"github.com/metal-toolbox/audito-maldito/ingesters/syslog/fakes"
 	"github.com/metal-toolbox/audito-maldito/internal/health"
-
-	"go.uber.org/zap"
 )
 
 func TestIngest(t *testing.T) {

--- a/ingesters/syslog/syslogingester_test.go
+++ b/ingesters/syslog/syslogingester_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestIngest(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := os.MkdirTemp("", "")
 	pipePath := fmt.Sprintf("%s/sshd-pipe", tmpDir)
 

--- a/ingesters/syslog/syslogingester_test.go
+++ b/ingesters/syslog/syslogingester_test.go
@@ -21,10 +21,6 @@ func TestIngest(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/sshd-pipe", tmpDir)
-
-	defer func() {
-		os.RemoveAll(tmpDir)
-	}()
 	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
 		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)

--- a/ingesters/syslog/syslogingester_test.go
+++ b/ingesters/syslog/syslogingester_test.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
 	"github.com/metal-toolbox/audito-maldito/ingesters/syslog"
@@ -25,7 +26,7 @@ func TestIngest(t *testing.T) {
 	}()
 	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
-		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
+		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}
 	countChan := make(chan int)
 	expectedPID := "10"
@@ -50,13 +51,13 @@ func TestIngest(t *testing.T) {
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
 		if err != nil {
-			t.Errorf("failed to initialize tests: Could not open %s named pipe", pipePath)
+			assert.Error(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
 		}
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString(expectedPID + " foo bar\n")
 			if err != nil {
-				t.Errorf("error writing to pipe %s", pipePath)
+				assert.Error(t, err, "error writing to pipe %s", pipePath)
 			}
 		}
 	}()

--- a/ingesters/syslog/syslogingester_test.go
+++ b/ingesters/syslog/syslogingester_test.go
@@ -17,16 +17,13 @@ import (
 func TestIngest(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Errorf("failed to initialize tests: Could not create %s dir", tmpDir)
-	}
+	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/sshd-pipe", tmpDir)
 
 	defer func() {
 		os.RemoveAll(tmpDir)
 	}()
-	err = syscall.Mkfifo(pipePath, 0o664)
+	err := syscall.Mkfifo(pipePath, 0o664)
 	if err != nil {
 		t.Errorf("failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
 	}

--- a/ingesters/syslog/syslogingester_test.go
+++ b/ingesters/syslog/syslogingester_test.go
@@ -22,9 +22,8 @@ func TestIngest(t *testing.T) {
 	tmpDir := t.TempDir()
 	pipePath := fmt.Sprintf("%s/sshd-pipe", tmpDir)
 	err := syscall.Mkfifo(pipePath, 0o664)
-	if err != nil {
-		assert.Error(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
-	}
+	assert.NoError(t, err, "failed to initialize tests: Could not create %s/%s named pipe", tmpDir, pipePath)
+
 	countChan := make(chan int)
 	expectedPID := "10"
 	h := health.NewSingleReadinessHealth("sshd")
@@ -46,15 +45,11 @@ func TestIngest(t *testing.T) {
 
 	go func() {
 		file, err := os.OpenFile(pipePath, os.O_WRONLY, os.ModeNamedPipe)
-		if err != nil {
-			assert.Error(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
-		}
+		assert.NoError(t, err, "failed to initialize tests: Could not open %s named pipe", pipePath)
 
 		for range []int{0, 1, 2, 3, 4} {
 			_, err := file.WriteString(expectedPID + " foo bar\n")
-			if err != nil {
-				assert.Error(t, err, "error writing to pipe %s", pipePath)
-			}
+			assert.NoError(t, err, "error writing to pipe %s", pipePath)
 		}
 	}()
 

--- a/processors/rocky/rockyprocessor.go
+++ b/processors/rocky/rockyprocessor.go
@@ -9,7 +9,7 @@ import (
 )
 
 type RockyProcessor struct {
-	SshdProcessor *sshd.SshdProcessor
+	SshdProcessor *sshd.SshdProcessorer
 }
 
 // pidRE regex matches a sshd log line extracting the procid and message into a match group

--- a/processors/sshd/sshdprocessor_test.go
+++ b/processors/sshd/sshdprocessor_test.go
@@ -358,7 +358,7 @@ func TestEntryProcessing(t *testing.T) {
 
 			logins := make(chan common.RemoteUserLogin, 1)
 			pprov := metrics.NewPrometheusMetricsProviderForRegisterer(pr)
-			err := ProcessEntry(&SshdProcessor{
+			err := ProcessEntry(&SshdProcessorer{
 				ctx:       ctx,
 				logins:    logins,
 				logEntry:  tt.args.logentry,

--- a/processors/varlogsecure/varlogsecure.go
+++ b/processors/varlogsecure/varlogsecure.go
@@ -33,7 +33,7 @@ type VarLogSecure struct {
 	AuWriter      *auditevent.EventWriter
 	Health        *health.Health
 	Metrics       *metrics.PrometheusMetricsProvider
-	SshdProcessor *sshd.SshdProcessor
+	SshdProcessor sshd.SshdProcessor
 }
 
 // Read reads from /var/log/secure and processes the lines into


### PR DESCRIPTION
  * auditlog ingester reads from a named pipe that contains content from /var/log/audit/audit.log\
  * syslog ingester reads from a named pipe that contains content from a PID and the msg from syslog / journald
  * rocky processor reads from a named that contains content from /var/log/secure