### PR TITLE
auditd: Make test reliable w/ TestAuditEncoder.Err,

### DIFF
--- a/processors/auditd/auditd.go
+++ b/processors/auditd/auditd.go
@@ -58,8 +58,9 @@ type Auditd struct {
 	Health *health.Health
 }
 
-// TODO: Write documentation about creating a splunk query that shows
-// only events after a user-start.
+// Read reads Linux audit messages from Auditd.Logins, parsing them into
+// Linux audit messages. It correlates the Linux audit events and their
+// session IDs with remote user logins sourced from Auditd.Logins.
 func (o *Auditd) Read(ctx context.Context) error {
 	reassemblerErrors := make(chan error, 1)
 	tracker := sessiontracker.NewSessionTracker(o.EventW, logger)

--- a/processors/auditd/auditd_good_test.go
+++ b/processors/auditd/auditd_good_test.go
@@ -193,10 +193,9 @@ func TestAuditd_Read_GoodAuditdEventsFirst(t *testing.T) {
 //	r1: allowWrites - a function that, when executed, will start
 //	                  reading lines from the slice
 //
-//	r2: writesDone - a channel that is either written to when
-//	                 if an error occurs (such as ctx being
-//	                 cancelled) or is closed when all lines
-//	                 have been written to the lines channel
+//	r2: writesDone - a channel that receives an error if one occurs
+//	                 (such as ctx being cancelled) and is closed when
+//	                 all lines have been written to the lines channel
 func newTestLogReader(
 	ctx context.Context,
 	lineSetsToSend []string,


### PR DESCRIPTION
This unit test (renamed in the commit for accuracy) was failing intermittently due to the cancellation of the context.Context racing with a channel write to a buffered channel (well, that is what I think was happening anyways).

This commit updates the problematic test to use the TestAuditEncoder.Err field, which is checked by the Write method prior to writing the AuditEvent - thus avoiding any races / inconsistent behavior.