### PR TITLE
auditd: Clarify SessionTrackerError failures.

### DIFF
--- a/processors/auditd/auditd_test.go
+++ b/processors/auditd/auditd_test.go
@@ -147,8 +147,8 @@ func TestAuditd_Read_AuditEventWriterError(t *testing.T) {
 
 	assert.ErrorAs(t, err, &expErr)
 
-	if !expErr.AuditEventFailed() {
-		t.Fatal("expected audit event fail to be true - it is false")
+	if !expErr.AuditEventWriteFailed() {
+		t.Fatal("expected audit event write fail to be true - it is false")
 	}
 
 	assert.ErrorIs(t, err, expInnerErr)

--- a/processors/auditd/auditd_test.go
+++ b/processors/auditd/auditd_test.go
@@ -147,9 +147,10 @@ func TestAuditd_Read_AuditEventWriterError(t *testing.T) {
 
 	assert.ErrorAs(t, err, &expErr)
 
-	if !expErr.AuditEventWriteFailed() {
-		t.Fatal("expected audit event write fail to be true - it is false")
-	}
+	require.True(
+		t,
+		expErr.AuditEventWriteFailed(),
+		"expected audit event write fail to be true - it is false")
 
 	assert.ErrorIs(t, err, expInnerErr)
 }

--- a/processors/auditd/sessiontracker/errors.go
+++ b/processors/auditd/sessiontracker/errors.go
@@ -2,7 +2,8 @@ package sessiontracker
 
 type SessionTrackerError struct {
 	remoteLoginFail bool
-	auditEventFail  bool
+	parsePIDFail    bool
+	auditWriteFail  bool
 	message         string
 	inner           error
 }
@@ -11,8 +12,12 @@ func (o *SessionTrackerError) RemoteLoginFailed() bool {
 	return o.remoteLoginFail
 }
 
-func (o *SessionTrackerError) AuditEventFailed() bool {
-	return o.auditEventFail
+func (o *SessionTrackerError) ParsePIDFailed() bool {
+	return o.parsePIDFail
+}
+
+func (o *SessionTrackerError) AuditEventWriteFailed() bool {
+	return o.auditWriteFail
 }
 
 func (o *SessionTrackerError) Error() string {

--- a/processors/auditd/sessiontracker/sessiontracker.go
+++ b/processors/auditd/sessiontracker/sessiontracker.go
@@ -189,7 +189,7 @@ func (o *sessionTracker) auditEventWithSession(event *aucoalesce.Event, debugLog
 		err := u.writeAndClearCache(o.eventWriter)
 		if err != nil {
 			return &SessionTrackerError{
-				auditEventFail: true,
+				auditWriteFail: true,
 				message: fmt.Sprintf("failed to write cached events for user '%s' - %s",
 					u.login.CredUserID, err),
 				inner: err,
@@ -199,7 +199,7 @@ func (o *sessionTracker) auditEventWithSession(event *aucoalesce.Event, debugLog
 		err = o.eventWriter.Write(u.toAuditEvent(event))
 		if err != nil {
 			return &SessionTrackerError{
-				auditEventFail: true,
+				auditWriteFail: true,
 				message:        err.Error(),
 				inner:          err,
 			}
@@ -228,7 +228,7 @@ func (o *sessionTracker) auditEventWithoutSession(event *aucoalesce.Event, debug
 	srcPID, err := strconv.Atoi(event.Process.PID)
 	if err != nil {
 		return &SessionTrackerError{
-			auditEventFail: true,
+			parsePIDFail: true,
 			message: fmt.Sprintf("failed to parse audit session init event pid for session id '%s' ('%s') - %s",
 				event.Session, event.Process.PID, err),
 			inner: err,
@@ -253,7 +253,7 @@ func (o *sessionTracker) auditEventWithoutSession(event *aucoalesce.Event, debug
 			err = o.eventWriter.Write(u.toAuditEvent(event))
 			if err != nil {
 				return &SessionTrackerError{
-					auditEventFail: true,
+					auditWriteFail: true,
 					message:        err.Error(),
 					inner:          err,
 				}

--- a/processors/auditd/sessiontracker/sessiontracker.go
+++ b/processors/auditd/sessiontracker/sessiontracker.go
@@ -33,9 +33,6 @@ func NewSessionTracker(eventWriter *auditevent.EventWriter, l *zap.SugaredLogger
 // sessionTracker tracks both remote user logins and auditd sessions,
 // allowing us to correlate auditd events back to the credential
 // a user used to authenticate.
-//
-// This struct's methods are not thread-safe (i.e., they are intended
-// to be called by a single Go routine).
 type sessionTracker struct {
 	// sessIDsToUsers contains active auditd sessions which may
 	// or may not have a common.RemoteUserLogin associated with

--- a/processors/auditd/sessiontracker/sessiontracker_test.go
+++ b/processors/auditd/sessiontracker/sessiontracker_test.go
@@ -508,8 +508,9 @@ func TestSessionTracker_AuditdEvent_CreateSession_BadPID(t *testing.T) {
 
 	err := st.AuditdEvent(initialEvent)
 
-	var exp *strconv.NumError
+	var exp *SessionTrackerError
 	assert.ErrorAs(t, err, &exp)
+	assert.True(t, exp.ParsePIDFailed())
 }
 
 func TestSessionTracker_AuditdEvent_CreateSession_WithRUL(t *testing.T) {


### PR DESCRIPTION
The auditEventFail field was overloaded to represent two different failures scenarios:

- PID parse failures
- Failures when writing to the AuditEventWriter.

This commit makes the failures explicit.