### PR TITLE
Explicitly set goproxy to use proxy and direct to fetch packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   test:
     name: test
+    env:
+      GOPROXY: https://proxy.golang.org,direct
     runs-on: ubuntu-latest
     container: registry.fedoraproject.org/fedora-minimal:37
     steps:


### PR DESCRIPTION
This is to work around proxying issues in GitHub

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
