### PR TITLE
auditd: Give up writing error if channel full.

### DIFF
--- a/processors/auditd/reassembler_callback.go
+++ b/processors/auditd/reassembler_callback.go
@@ -23,9 +23,12 @@ type reassemblerCB struct {
 func (s *reassemblerCB) ReassemblyComplete(msgs []*auparse.AuditMessage) {
 	event, err := aucoalesce.CoalesceMessages(msgs)
 	if err != nil {
-		s.errors <- &reassemblerCBError{
+		select {
+		case s.errors <- &reassemblerCBError{
 			message: fmt.Sprintf("failed to coalesce audit messages - %s", err),
 			inner:   err,
+		}:
+		default:
 		}
 
 		return
@@ -38,9 +41,12 @@ func (s *reassemblerCB) ReassemblyComplete(msgs []*auparse.AuditMessage) {
 	aucoalesce.ResolveIDs(event)
 
 	if err := s.au.AuditdEvent(event); err != nil {
-		s.errors <- &reassemblerCBError{
+		select {
+		case s.errors <- &reassemblerCBError{
 			message: fmt.Sprintf("failed to audit audit event - %s", err),
 			inner:   err,
+		}:
+		default:
 		}
 	}
 }


### PR DESCRIPTION
Prior to this change, I noticed TestAuditd_Read_AuditEventWriterError would occasionally fail with the error: "panic: test timed out after 10m0s". This can be seen in the linked GitHub CI run. [1]

I was able to reproduce this failure by re-running the test several times locally. [2] I am not entirely sure what the failure is caused by, as adding logging caused the issue to stop occurring). Looking at the CI log, it seems like the ReassemblyComplete method was called by two different Go routines. The Go routines became blocked trying to write to the errors channel. [1]

I noticed that the reassemblerCB callback does not bound the errors channel write with any other event. As a result, a blocked write will cause a deadlock.

There are at least two ways to deal with this:

1. Bound the errors channel write with a read that indicates when the callback should stop doing work
2. Give up writing to the channel if there is no capacity in the channel (this would be acceptable simply because we set a capacity of one error for the errors channel, thus one error will always be successfully written)

I opted for the second option because it is the simplest.

References:

1. https://github.com/metal-toolbox/audito-maldito/actions/runs/5158110846/jobs/9291366073
2.
```
while /bin/sh -c 'timeout 4 go test -run TestAuditd_Read_AuditEventWriterError || (echo error: timed-out && return 1)'; do :; done
PASS ok  	github.com/metal-toolbox/audito-maldito/processors/auditd	0.012s
PASS ok  	github.com/metal-toolbox/audito-maldito/processors/auditd	0.012s
PASS ok  	github.com/metal-toolbox/audito-maldito/processors/auditd	0.012s
error: timed-out
```