### PR TITLE
sshd: Use '.*' for regex. Add accept pw test.

### DIFF
--- a/processors/sshd/openssh_regex.go
+++ b/processors/sshd/openssh_regex.go
@@ -68,7 +68,7 @@ var (
 	//	    extra != NULL ? extra : "");
 	//
 	//nolint:lll // This is a long regex... pretty hard to cut it without making it less readable.
-	loginRE = regexp.MustCompile(`Accepted publickey for (?P<Username>\S+) from (?P<Source>\S+) port (?P<Port>\d+) ssh[[:alnum:]]+: (?P<Alg>[\w -]+):(?P<SSHKeySum>\S+)`)
+	loginRE = regexp.MustCompile(`Accepted publickey for (?P<Username>.*) from (?P<Source>.*) port (?P<Port>.*) ssh[[:alnum:]]+: (?P<Alg>[\w -]+):(?P<SSHKeySum>\S+)`)
 
 	// passwordLoginRE matches the sshd password login log message,
 	// allowing us to extract information about the login attempt,
@@ -79,7 +79,7 @@ var (
 	//	Accepted password for auditomalditotesting from 127.0.0.1 port 45082 ssh2
 	//
 	//nolint:lll // This is a long regex... pretty hard to cut it without making it less readable.
-	passwordLoginRE = regexp.MustCompile(`Accepted password for (?P<Username>\S+) from (?P<Source>\S+) port (?P<Port>\d+) ssh[[:alnum:]]+`)
+	passwordLoginRE = regexp.MustCompile(`Accepted password for (?P<Username>.*) from (?P<Source>.*) port (?P<Port>\d+) ssh[[:alnum:]]+`)
 
 	// failedPasswordAuthRE matches an OpenSSH log message that occurs
 	// when the user fails to authenticate with a password. This log
@@ -108,7 +108,7 @@ var (
 	//	          cafp == NULL ? "(null)" : cafp,
 	//	          methinfo == NULL ? "" : ", ",
 	//	          methinfo == NULL ? "" : methinfo);
-	certIDRE = regexp.MustCompile(`ID (?P<UserID>\S+)\s+\(serial (?P<Serial>\d+)\)\s+(?P<CA>.+)`)
+	certIDRE = regexp.MustCompile(`ID (?P<UserID>.*) \(serial (?P<Serial>\d+)\)\s+(?P<CA>.+)`)
 
 	// invalidUserRE matches the sshd invalid user log message,
 	// allowing us to extract information about the user.
@@ -128,7 +128,7 @@ var (
 	//	   "not listed in AllowUsers", pw->pw_name, hostname);
 	//
 	//nolint:lll // This is a long regex... pretty hard to cut it without making it less readable.
-	notInAllowUsersRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>\S+) not allowed because not listed in AllowUsers$`)
+	notInAllowUsersRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>.*) not allowed because not listed in AllowUsers$`)
 
 	// userNonExistentShellRE matches an OpenSSH log message that
 	// occurs when the user's shell does not exist.
@@ -139,7 +139,7 @@ var (
 	//	   "does not exist", pw->pw_name, shell);
 	//
 	//nolint:lll // This is a long regex
-	userNonExistentShellRE = regexp.MustCompile(`^User (?P<Username>.*) not allowed because shell (?P<Shell>\S+) does not exist$`)
+	userNonExistentShellRE = regexp.MustCompile(`^User (?P<Username>.*) not allowed because shell (?P<Shell>.*) does not exist$`)
 
 	// userNonExecutableShellRE matches an OpenSSH log message that
 	// occurs when the user's shell is not executable.
@@ -150,7 +150,7 @@ var (
 	//	   "is not executable", pw->pw_name, shell);
 	//
 	//nolint:lll // This is a long regex
-	userNonExecutableShellRE = regexp.MustCompile(`^User (?P<Username>.*) not allowed because shell (?P<Shell>\S+) is not executable$`)
+	userNonExecutableShellRE = regexp.MustCompile(`^User (?P<Username>.*) not allowed because shell (?P<Shell>.*) is not executable$`)
 
 	// userInDenyUsersRE matches an OpenSSH log message that occurs
 	// when the user is listed in DenyUsers.
@@ -164,7 +164,7 @@ var (
 	//	   pw->pw_name, hostname);
 	//
 	//nolint:lll // This is a long regex
-	userInDenyUsersRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>\S+) not allowed because listed in DenyUsers$`)
+	userInDenyUsersRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>.*) not allowed because listed in DenyUsers$`)
 
 	// userNotInAnyGroupRE matches an OpenSSH log message that
 	// occurs when the user is not in any group.
@@ -175,7 +175,7 @@ var (
 	//	   "not in any group", pw->pw_name, hostname);
 	//
 	//nolint:lll // This is a long regex
-	userNotInAnyGroupRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>\S+) not allowed because not in any group$`)
+	userNotInAnyGroupRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>.*) not allowed because not in any group$`)
 
 	// userGroupInDenyGroupsRE matches an OpenSSH log message that
 	// occurs when the user's group is listed in DenyUsers.
@@ -189,7 +189,7 @@ var (
 	//	   pw->pw_name, hostname);
 	//
 	//nolint:lll // This is a long regex
-	userGroupInDenyGroupsRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>\S+) not allowed because a group is listed in DenyGroups$`)
+	userGroupInDenyGroupsRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>.*) not allowed because a group is listed in DenyGroups$`)
 
 	// userGroupNotListedInAllowGroupsRE matches an OpenSSH log
 	// message that occurs when none of the user's groups appear
@@ -204,7 +204,7 @@ var (
 	//	    "in AllowGroups", pw->pw_name, hostname);
 	//
 	//nolint:lll // This is a long regex
-	userGroupNotListedInAllowGroupsRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>\S+) not allowed because none of user's groups are listed in AllowGroups$`)
+	userGroupNotListedInAllowGroupsRE = regexp.MustCompile(`^User (?P<Username>.*) from (?P<Source>.*) not allowed because none of user's groups are listed in AllowGroups$`)
 
 	// rootLoginRefusedRE matches an OpenSSH log message that occurs
 	// when a root user login attempt fails.
@@ -213,7 +213,7 @@ var (
 	//
 	//	logit("ROOT LOGIN REFUSED FROM %.200s port %d",
 	//	    ssh_remote_ipaddr(ssh), ssh_remote_port(ssh));
-	rootLoginRefusedRE = regexp.MustCompile(`^ROOT LOGIN REFUSED FROM (?P<Source>\S+) port (?P<Port>\d+)$`)
+	rootLoginRefusedRE = regexp.MustCompile(`^ROOT LOGIN REFUSED FROM (?P<Source>.*) port (?P<Port>.*)$`)
 
 	// badOwnerOrModesForHostFileRE matches an OpenSSH log message
 	// that occurs when a user's authorized_keys file has incorrect
@@ -237,7 +237,7 @@ var (
 	//
 	//	logit("Nasty PTR record \"%s\" is set up for %s, ignoring",
 	//	    name, ntop);
-	nastyPTRRecordRE = regexp.MustCompile(`^Nasty PTR record "(?P<DNSName>\S+)" is set up for (?P<Source>\S+), ignoring$`)
+	nastyPTRRecordRE = regexp.MustCompile(`^Nasty PTR record "(?P<DNSName>.*)" is set up for (?P<Source>.*), ignoring$`)
 
 	// reverseMappingCheckFailedRE matches an OpenSSH log message
 	// that occurs when the reverse DNS lookup fails.
@@ -250,7 +250,7 @@ var (
 	//	    "[%s] failed.", name, ntop);
 	//
 	//nolint:lll // This is a long regex
-	reverseMappingCheckFailedRE = regexp.MustCompile(`^reverse mapping checking getaddrinfo for (?P<DNSName>\S+) \[(?P<Source>\S+)\] failed.$`)
+	reverseMappingCheckFailedRE = regexp.MustCompile(`^reverse mapping checking getaddrinfo for (?P<DNSName>.*) \[(?P<Source>.*)\] failed.$`)
 
 	// doesNotMapBackToAddrRE matches an OpenSSH log message that
 	// occurs when the reverse DNS lookup yields a record that does
@@ -264,7 +264,7 @@ var (
 	//	    "map back to the address.", ntop, name);
 	//
 	//nolint:lll // This is a long regex
-	doesNotMapBackToAddrRE = regexp.MustCompile(`^Address (?P<Source>\S+) maps to (?P<DNSName>\S+), but this does not map back to the address.$`)
+	doesNotMapBackToAddrRE = regexp.MustCompile(`^Address (?P<Source>.*) maps to (?P<DNSName>.*), but this does not map back to the address.$`)
 
 	// maxAuthAttemptsExceededRE matches an OpenSSH log message that
 	// occurs when the maximum authentication attempt limit is exceeded
@@ -280,7 +280,7 @@ var (
 	//	    ssh_remote_port(ssh));
 	//
 	//nolint:lll // This is a long regex
-	maxAuthAttemptsExceededRE = regexp.MustCompile(`^maximum authentication attempts exceeded for (?P<Username>.*) from (?P<Source>.*) port (?P<Port>\d+) ssh[[:alnum:]]+$`)
+	maxAuthAttemptsExceededRE = regexp.MustCompile(`^maximum authentication attempts exceeded for (?P<Username>.*) from (?P<Source>.*) port (?P<Port>.*) ssh[[:alnum:]]+$`)
 
 	// revokedPublicKeyByFileRE matches an OpenSSH log message that
 	// occurs when the client's public key appears in the file named


### PR DESCRIPTION
The processAcceptedPasswordEntry function was untested. I also added some additional characters to the "exp" test constants.