### PR TITLE
main: Exit if input files are not named pipes.

### DIFF
--- a/internal/common/namedpipe.go
+++ b/internal/common/namedpipe.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"errors"
+	"os"
+)
+
+var errNotNamedPipe = errors.New("not a named pipe")
+
+// IsNamedPipe returns a non-nil error if filePath cannot be stat'ed
+// or if it is not a named pipe.
+func IsNamedPipe(filePath string) error {
+	sshdLogFileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+
+	if (sshdLogFileInfo.Mode() & os.ModeNamedPipe) == os.ModeNamedPipe {
+		return nil
+	}
+
+	return errNotNamedPipe
+}

--- a/internal/common/namedpipe_test.go
+++ b/internal/common/namedpipe_test.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNamedPipe(t *testing.T) {
+	t.Parallel()
+
+	namedPipePath := filepath.Join(t.TempDir(), "foo.pipe")
+
+	require.NoError(t, syscall.Mkfifo(namedPipePath, 0o600))
+
+	require.NoError(t, IsNamedPipe(namedPipePath))
+}
+
+func TestIsNamedPipe_RegularFile(t *testing.T) {
+	t.Parallel()
+
+	regularFilePath := filepath.Join(t.TempDir(), "foo.txt")
+
+	regularFile, err := os.Create(regularFilePath)
+	require.NoError(t, err)
+	_ = regularFile.Close()
+
+	require.ErrorIs(t, IsNamedPipe(regularFilePath), errNotNamedPipe)
+}
+
+func TestIsNamedPipe_StatFailure(t *testing.T) {
+	t.Parallel()
+
+	regularFilePath := filepath.Join(t.TempDir(), string([]byte{0x90, 0x90, 0x90, 0x90}))
+
+	var expErr *os.PathError
+
+	require.ErrorAs(t, IsNamedPipe(regularFilePath), &expErr)
+}


### PR DESCRIPTION
In discussions with the team, we decided that the input files will always be named pipes. As a result, we felt it was necessary to enforce a file-type check that produces a helpful error message.