### PR TITLE
Fix image signing on rsyslog image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,14 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign -y -r ${images}
+
+      - name: Sign rsyslog container image
+        env:
+          DIGEST: ${{ steps.rsyslog-build-push.outputs.digest }}
+          TAGS: ${{ steps.rsyslog-metadata.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign -y -r ${images}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,4 +85,9 @@ jobs:
         env:
           DIGEST: ${{ steps.am-build-push.outputs.digest }}
           TAGS: ${{ steps.am-metadata.outputs.tags }}
-        run: cosign sign -y -r "${TAGS}@${DIGEST}"
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign -y -r ${images}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: sigstore/cosign-installer@v3.1.1
+      - uses: sigstore/cosign-installer@v3.9.2
         with:
-          cosign-release: "v2.2.1"
+          cosign-release: "v2.5.3"
 
       - name: Get current date
         id: date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           context: "./contrib/rsyslog"
           push: true
           file: ./contrib/rsyslog/Dockerfile.ubuntu
-          tags: ${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}:${{ github.ref_name }}-rsyslog
+          tags: ${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}-rsyslog:${{ github.ref_name }}
           labels: ${{ steps.rsyslog-metadata.outputs.labels }}
 
       - name: Build and push Docker image


### PR DESCRIPTION
This updates the cosign step to use the same method of constructing the image path to sign as in the [cosign-installer example ](https://github.com/marketplace/actions/cosign-installer)

The rsyslog image is renamed to use `-rsyslog` as part of the path not as part of the tag as this previously broke the signing step for the rsyslog image. (this will need to be updated in the [helm chart](https://github.com/equinixmetal-helm/audito-maldito/blob/ac30894686dc33730382096575fe1a0ba112f741/templates/ds.yaml#L132) when the version in the helm chart is updated.)

Now that the image is renamed, the signing step has been added for the rsyslog image.

As example of this action running can be found here: https://github.com/oliver-equinix/audito-maldito/actions/runs/17293110098